### PR TITLE
Remove duplicated backslash from line breaks in user-data

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -623,6 +623,10 @@ func replaceUserdataFile(machineName, machineOS string, userdataContent, customS
 	case bytes.HasPrefix(userdataContent, []byte("#cloud-config")):
 		// The user provided a cloud-config file, so the customInstallScript context is added to the
 		// "runcmd" section of the YAML.
+
+		// Remove duplicated "\" in line breaks
+		userdataContent = bytes.Replace(userdataContent, []byte("\\n"), []byte("\n"), -1)
+
 		if err := yaml.Unmarshal(userdataContent, &cf); err != nil {
 			return err
 		}


### PR DESCRIPTION
Rancher GUI is adding an extra backslash ("\") to line breaks ("\n") in userDataFile fields, so cloud-init scripts are not passed to machines. This change fixes the issue by searching and removing the extra character.